### PR TITLE
Fix issues with auto-publish to npm

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,7 +29,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: yarn run changeset publish
+          publish: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "prepack": "yarn build && yarn test",
+    "release": "yarn build && changeset publish",
     "test": "jest"
   },
   "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "exclude": ["**/__tests__/**", "**/__testfixtures__/**"]
+  "exclude": ["**/dist/**", "**/__tests__/**", "**/__testfixtures__/**"]
 }


### PR DESCRIPTION
Adds release command as per:
* Docs: https://github.com/changesets/action#with-publishing
* Example: https://github.com/changesets/changesets/blob/ed63f12b498d09fe8a389b4b57fe034ceee78f2d/package.json#L19

Manually run `yarn release` and verified it was successful:

```console
$ yarn release
🦋  info npm info aws-sdk-js-v2-to-v3
🦋  warn Received 404 for npm info "aws-sdk-js-v2-to-v3"
🦋  info aws-sdk-js-v2-to-v3 is being published because our local version (0.0.1) has not been published on npm
🦋  info Publishing "aws-sdk-js-v2-to-v3" at "0.0.1"
🦋  success packages published successfully:
🦋  aws-sdk-js-v2-to-v3@0.0.1
🦋  Creating git tag...
🦋  New tag:  v0.0.1
```