### PR TITLE
Downgrade TypeScript to 4.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prettier": "2.5.1",
     "simple-git-hooks": "2.7.0",
     "ts-jest": "27.1.3",
-    "typescript": "4.6.2"
+    "typescript": "4.5.5"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1832,7 +1832,7 @@ __metadata:
     prettier: 2.5.1
     simple-git-hooks: 2.7.0
     ts-jest: 27.1.3
-    typescript: 4.6.2
+    typescript: 4.5.5
   languageName: unknown
   linkType: soft
 
@@ -6982,23 +6982,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.6.2":
-  version: 4.6.2
-  resolution: "typescript@npm:4.6.2"
+"typescript@npm:4.5.5":
+  version: 4.5.5
+  resolution: "typescript@npm:4.5.5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 8a44ed7e6f6c4cb1ebe8cf236ecda2fb119d84dcf0fbd77e707b2dfea1bbcfc4e366493a143513ce7f57203c75da9d4e20af6fe46de89749366351046be7577c
+  checksum: 506f4c919dc8aeaafa92068c997f1d213b9df4d9756d0fae1a1e7ab66b585ab3498050e236113a1c9e57ee08c21ec6814ca7a7f61378c058d79af50a4b1f5a5e
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@4.6.2#~builtin<compat/typescript>":
-  version: 4.6.2
-  resolution: "typescript@patch:typescript@npm%3A4.6.2#~builtin<compat/typescript>::version=4.6.2&hash=bda367"
+"typescript@patch:typescript@4.5.5#~builtin<compat/typescript>":
+  version: 4.5.5
+  resolution: "typescript@patch:typescript@npm%3A4.5.5#~builtin<compat/typescript>::version=4.5.5&hash=bda367"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 40b493a71747fb89fa70df104e2c4a5e284b43750af5bea024090a5261cefa387f7a9372411b13030f7bf5555cee4275443d08805642ae5c74ef76740854a4c7
+  checksum: 858c61fa63f7274ca4aaaffeced854d550bf416cff6e558c4884041b3311fb662f476f167cf5c9f8680c607239797e26a2ee0bcc6467fbc05bfcb218e1c6c671
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reason: It's not officially supported by ESLint yet, and it throws following warning:

```console
$ yarn lint
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.3.1 <4.6.0

YOUR TYPESCRIPT VERSION: 4.6.2

Please only submit bug reports when using the officially supported version.

=============
```