### PR TITLE
Set engines to node >=12.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "typescript": "4.6.2"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=12.0.0"
   },
   "packageManager": "yarn@3.2.0",
   "lint-staged": {


### PR DESCRIPTION
Missed in https://github.com/trivikr/aws-sdk-js-v2-to-v3/pull/18