### PR TITLE
Output esbuild bundle at dist/index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/trivikr/aws-sdk-js-v2-to-v3.git"
   },
   "scripts": {
-    "build": "esbuild --bundle src/index.ts --outfile='dist/index.min.js' --platform=node --minify",
+    "build": "esbuild --bundle src/index.ts --outfile='dist/index.js' --platform=node --minify",
     "lint": "eslint 'src/*.ts'",
     "release": "yarn build && changeset publish",
     "test": "jest",


### PR DESCRIPTION
Missed in https://github.com/trivikr/aws-sdk-js-v2-to-v3/pull/53

Verified that file is created in `dist/index.js`

```console
$ yarn build

  dist/index.js  2.5mb ⚠️

⚡ Done in 284ms
```